### PR TITLE
fix: release from main

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,6 @@
 {
   "debug": true,
+  "branches": ["main"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
## PR summary
Semantic release assumes master to be the release branch instead of main