### PR TITLE
chore: fixup bump

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -8,7 +8,7 @@
     [
       "@semantic-release/exec", 
       {
-        "prepareCmd": "bump2version --allow-dirty --current-version ${lastRelease.version} --new-version ${nextRelease.version} patch"
+        "prepareCmd": "bump2version --allow-dirty --current-version v${lastRelease.version} --new-version v${nextRelease.version} patch"
       }
     ],
     [


### PR DESCRIPTION
What: bump version doesn't work unless it has a previous version and go versioning is different per convention